### PR TITLE
Fix x-forwarded-for header calculation

### DIFF
--- a/reverse.go
+++ b/reverse.go
@@ -215,7 +215,7 @@ func addXForwardedForHeader(req *http.Request) {
 		// X-Forwarded-For information as a comma+space
 		// separated list and fold multiple headers into one.
 		if prior, ok := req.Header["X-Forwarded-For"]; ok {
-			clientIP = strings.Join(prior, ", ") + clientIP
+			clientIP = strings.Join(prior, ", ") + ", " + clientIP
 		}
 		req.Header.Set("X-Forwarded-For", clientIP)
 	}


### PR DESCRIPTION
Setting the x-forwarded-for header is actually broken as it omit the separator between IPs passed by clients and other reverse proxies and the actual client request.

Like in the current httputil.reverseproxy library (https://golang.org/src/net/http/httputil/reverseproxy.go?s=575:1776#L188) I suggest to add the following patch.

Thank's for the work,

Salim